### PR TITLE
Fix pedal axes. Fixes #8

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -1064,9 +1064,9 @@ static void xpadone_process_packet(struct usb_xpad *xpad, u16 cmd, unsigned char
 					(__u16) le16_to_cpup((__le16 *)(data + 8)));
 		} else if (xpad->mapping & MAP_THRUSTMASTER_WHEEL) {
 			input_report_abs(dev, ABS_Z,
-					((__u16) le16_to_cpup((__le16 *)(data + 10)))*2);
+					(__u16) le16_to_cpup((__le16 *)(data + 10)));
 			input_report_abs(dev, ABS_RZ,
-				((__u16) le16_to_cpup((__le16 *)(data + 8)))*2);
+					(__u16) le16_to_cpup((__le16 *)(data + 8)));
 		} else {
 			input_report_abs(dev, ABS_Z,
 					(__u16) le16_to_cpup((__le16 *)(data + 6)));


### PR DESCRIPTION
The range for Z / Rz is set to 0 - 1023 (https://github.com/Capure/xpad/blob/main/xpad.c#L1820)
The raw values for pedals are also in 0 - 1023 range, so there's no need to multiply.

Before this fix my accel pedal reached max value half-way through,  leaving a lot of extra headroom.
Now it works in full-range.
Another user had same issue and confirmed this fixes it for them.